### PR TITLE
Implement Space autotype identifier

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -141,6 +141,8 @@ ${line2}</span>"
         for word in ${stuff["$AUTOTYPE_field"]}; do
             if [[ $word == ":tab" ]]; then
                 xdotool key Tab
+            elif [[ $word == ":space" ]]; then
+                xdotool key space
             elif [[ $word == "pass" ]]; then
                 echo -n "${password}" | xdotool type --clearmodifiers --file -
             else


### PR DESCRIPTION
Allow :space identifier in autotype sequences. I find that useful to
auto-check/auto-uncheck those 'Keep me logged in' checkboxes.

Same as :tab, just send a 'xdotool key space' sequence.