### PR TITLE
Clarify configfile locations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ rofi-pass comes with a tiny helper script, which makes it easier to create new p
 Just run it with 
 
 ```
-addpass --name "My new Site" +user "zeltak" +branch "branch" +custom "foobar" +autotype "branch :tab user :tab pass"`.
+addpass --name "My new Site" +user "zeltak" +branch "branch" +custom "foobar" +autotype "branch :tab user :tab pass".
 ```
 
 * First argument `--name` is mandatory. This will be the filename of the new password entry.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Same for `:space`, which will hit the space key, can be used to activate checkbo
 * awk
 * bash
 
+## Configuration
+rofi-pass may read its configuration values from `/etc/rofi-pass` and/or `$HOME/.config/rofi-pass/config`.
+For an example configuration please take a look at the included `config.example` file.
+
 ## Extras
 rofi-pass comes with a tiny helper script, which makes it easier to create new pass entries.
 Just run it with 


### PR DESCRIPTION
- Possible locations of rofi-pass config files weren't mentioned in the README before.
- Also fix a superflous ` in example line.