### PR TITLE
Check if system-wide config exists before sourcing

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -6,8 +6,10 @@
 # enable extended globbing
 shopt -s nullglob globstar
 
-# read global config file
-source /etc/rofi-pass.conf
+# check if global config exists and load it
+if [[ -f /etc/rofi-pass.conf ]]; then
+    source /etc/rofi-pass.conf
+fi
 
 # check if local config exists and load it
 if [[ -f $HOME/.config/rofi-pass/config ]]; then


### PR DESCRIPTION
When /etc/rofi-pass.conf did not exist, rofi-pass would spit out an
error message to the console.
Better check for the file's existence before sourcing.