### PR TITLE
Remove doublet "clip" from example config

### DIFF
--- a/config.example
+++ b/config.example
@@ -44,5 +44,4 @@ edit="Alt+9"
 move="Alt+2"
 delete="Alt+3"
 copy_entry="Alt+c"
-clip=primary
 show="Control+Return"


### PR DESCRIPTION
Duplicates entry in line 33 – This was mildly confusing. ;-)