### PR TITLE
Parsing with ", " could lead to wrong results

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -500,8 +500,8 @@ fi
 
 # set help color                                                                                            
 if [[ $help_color == "" ]]; then
-    help_color=$(rofi -dump-xresources | grep 'rofi.color.normal' | awk -F ', ' '{ print $2 }')
-    help_separator_color=$(rofi -dump-xresources | grep 'rofi.color.normal' | awk -F ', ' '{ print $2 }')
+    help_color=$(rofi -dump-xresources | grep 'rofi.color.normal' | awk -F ',' '/,/{gsub(/ /, "", $2); print $2}')
+    help_separator_color=$(rofi -dump-xresources | grep 'rofi.color.normal' | awk -F ',' '/,/{gsub(/ /, "", $2); print $2}')
 fi
 
 # check for BROWSER variable, use xdg-open as fallback


### PR DESCRIPTION
Instead check on "," and remove whitespaces from the result.
This should fix #27