### PR TITLE
Makefile need Tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ ifndef PREFIX
 endif
 
 install:
-    install -Dm755 rofi-pass $(DESTDIR)$(PREFIX)/bin/rofi-pass
-    install -Dm755 addpass $(DESTDIR)$(PREFIX)/bin/addpass
-    install -Dm644 config.example $(DESTDIR)$(PREFIX)/share/doc/rofi-pass/config.example
-    install -Dm644 README.md $(DESTDIR)$(PREFIX)/share/doc/rofi-pass/README.md
-    install -Dm644 config.example $(DESTDIR)/etc/rofi-pass.conf
+	install -Dm755 rofi-pass $(DESTDIR)$(PREFIX)/bin/rofi-pass
+	install -Dm755 addpass $(DESTDIR)$(PREFIX)/bin/addpass
+	install -Dm644 config.example $(DESTDIR)$(PREFIX)/share/doc/rofi-pass/config.example
+	install -Dm644 README.md $(DESTDIR)$(PREFIX)/share/doc/rofi-pass/README.md
+	install -Dm644 config.example $(DESTDIR)/etc/rofi-pass.conf


### PR DESCRIPTION
Partially reverts my previous commit
_______
Didn't know about this requirement before, so my adaption on every file rendered the makefile useless

Although .RECIPEPREFIX can be set, but I suppose it's not really worth the hassle (and if you think about switching to tabs at whole)