### PR TITLE
Adding fix to handle *.gpg files with spaces

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -253,7 +253,7 @@ else unset helptext; mainMenu; fi
 
 typeMenu () {
     checkIfPass
-    typefield=$(echo -e "< Return\n---\npassword\n$(pass ${selected_password} | grep -P ':[\t ]' | awk -F ':' '{ print $1 }')" | _rofi -dmenu -p "Choose Field to type > ")
+    typefield=$(echo -e "< Return\n---\npassword\n$(pass "${selected_password}" | grep -P ':[\t ]' | awk -F ':' '{ print $1 }')" | _rofi -dmenu -p "Choose Field to type > ")
     if [[ $typefield == "" ]]; then exit;
     elif [[ $typefield == "password" ]]; then typePass;
     elif [[ $typefield == "< Return" ]]; then mainMenu;
@@ -263,7 +263,7 @@ typeMenu () {
 
 copyMenu () {
     checkIfPass
-    copyfield=$(echo -e "< Return\n---\npassword\n$(pass ${selected_password} | grep -P ':[\t ]' | awk -F ':' '{ print $1 }')" | _rofi -dmenu -p "Choose Field to copy > ")
+    copyfield=$(echo -e "< Return\n---\npassword\n$(pass "${selected_password}" | grep -P ':[\t ]' | awk -F ':' '{ print $1 }')" | _rofi -dmenu -p "Choose Field to copy > ")
     if [[ $copyfield == "" ]]; then exit;
     elif [[ $copyfield == "password" ]]; then copyPass;
     elif [[ $copyfield == "< Return" ]]; then mainMenu;


### PR DESCRIPTION
Some of my functions like "Type Field" were not finding the right gpg file, due to it having a space.  Adding quotes around the selection fixes this.