### PR TITLE
remove static path to bash

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # rofi-pass
 # (c) 2015 Rasmus Steinke <rasi@xssn.at>


### PR DESCRIPTION
Not all systems install bash into /bin (FreeBSD and OpenBSD for example).

This switches to `env` which lets us find bash anywhere in $PATH. `/usr/bin/env` exists on virtually every system claiming to be POSIX compliant.