### PR TITLE
Disable keyboard repeat for autopass

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -75,6 +75,9 @@ checkIfPass () {
 
 
 autopass () {
+  x_repeat_enabled=$(xset q | awk '/auto repeat:/ {print $3}')
+  xset r off
+
   rm -f "$HOME/.cache/rofi-pass/last_used"
   echo "${root}: $selected_password" > "$HOME/.cache/rofi-pass/last_used"
   if [[ -z "${stuff["$AUTOTYPE_field"]}" ]]; then
@@ -107,6 +110,10 @@ autopass () {
       xdotool key Return
     fi
   fi
+
+  xset r "$x_repeat_enabled"
+  unset x_repeat_enabled
+
   clearUp
 }
 


### PR DESCRIPTION
This commit disables keyboard auto repeat during automatic password entry with xdotool, and reenables auto repeat afterwards only if it was enabled before. This procedure reduces accidentally repeated keys a lot. The keyboard repeat rate is never changed.

Closes #67 