### PR TITLE
Use find instead of globstar

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -49,12 +49,10 @@ umask 077
 # get all password files and create an array
 list_passwords() {
   cd "${root}" || exit
-    passwords=( **/*.gpg )
 
-  for password in "${passwords[@]}"; do
-    filename="${password}"
-    filename="${filename%.gpg}"
-    echo "$filename"
+  find -L . -iname '*.gpg' -printf '%P\n' | \
+    while read filename; do
+      echo "${filename%.gpg}"
   done
 }
 


### PR DESCRIPTION
In my password store in have symlinks to other directories (pointing to
a separate git repository with passwords):

    ~/.password-store
    ├── foo.txt.gpg
    ├── Hardware -> /home/user/repos/passwords-Hardware
    └── secret.txt.gpg

In the "passwords-Hardware" repo the structure was as follows:

    ~/repos/passwords-Hardware:
    ├── device.txt.gpg
    ├── extern
    │   └── simple.txt.gpg
    └── other.txt.gpg

I wondered why rofi-pass would only show some passwords stored in the
other repository (namely `device.txt` and `other.txt`), but not the
files from the subdir (`simple.txt`).

Today I took the time to properly debug this. Turns out, the bash
`globstar` option doesn't play well with symlinks (as opposed to the
original zsh implementation, which I've been happily using for years):
In bash, `**` matches a symlink, but nothing below the symlink (if it
points to a directory). So `**/*.gpg` matches `device.txt.gpg` and
`other.txt.gpg`, but not `extern/simple.txt.gpg`.

Using `pass` works very well (as it has been for years), because it also
traverses symlinked directories.

So I propose not using `globstar` for finding the passwords in the repo.
This commit switches to calling `find`. The code used here is safe with
filenames containing whitespaces.

Let me know what you think.