### PR TITLE
Remove double definition of password_length

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -19,7 +19,6 @@ delay=2
 default_do='menu' # menu, copyPass, typeUser, typePass, copyUser, copyUrl, viewEntry, typeMenu, actionMenu, copyMenu, openUrl
 auto_enter='false'
 notify='false'
-password_length='20'
 help_color=""
 clip=primary
 default_user="$(whoami)"


### PR DESCRIPTION
Second definition (a few lines below) makes this one
effectively useless.