### PR TITLE
Follow symlinks in the pass store

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -529,7 +529,7 @@ manageEntry () {
     mainMenu
   elif [[ $1 == "move" ]]; then
     cd "${root}" || exit
-    group=$(find . -type d -not -iwholename '*.git*' -printf '%d\t%P\n' | sort -r -nk1 | cut -f2- | _rofi -dmenu -p "Choose Group > ")
+    group=$(find -L . -type d -not -iwholename '*.git*' -printf '%d\t%P\n' | sort -r -nk1 | cut -f2- | _rofi -dmenu -p "Choose Group > ")
     if [[ $group == "" ]]; then
       exit
     fi
@@ -537,7 +537,7 @@ manageEntry () {
       mainMenu
   elif [[ $1 == "copy" ]]; then
     cd "${root}" || exit
-    group=$(find . -type d -not -iwholename '*.git*' -printf '%d\t%P\n' | sort -r -nk1 | cut -f2- | _rofi -dmenu -p "Choose Group > ")
+    group=$(find -L . -type d -not -iwholename '*.git*' -printf '%d\t%P\n' | sort -r -nk1 | cut -f2- | _rofi -dmenu -p "Choose Group > ")
     if [[ $group == "" ]]; then
       exit
     else
@@ -564,7 +564,7 @@ manageEntry () {
 }
 
 listgpg () {
-  find . -type f -not -path '*/\.*' | cut -c 3-
+  find -L . -type f -not -path '*/\.*' | cut -c 3-
 }
 
 insertPass () {
@@ -579,7 +579,7 @@ Type name, make sure it is unique"
 Type name, make sure it is unique"
   fi
   cd "${root}" || exit
-  grouplist="$(find . -type d -not -iwholename '*.git*' -printf '%d\t%P\n' | sort -r -nk1 | cut -f2-)"
+  grouplist="$(find -L . -type d -not -iwholename '*.git*' -printf '%d\t%P\n' | sort -r -nk1 | cut -f2-)"
   name="$(listgpg | _rofi -dmenu -format 'f' -filter "${domain_name}" -mesg "${help_content}" -p "> ")"
   val=$?
   if [[ $val -eq 1 ]]; then


### PR DESCRIPTION
It's possible to have a pass store like this:

    ~/pass-store/company1 -> symlink to -> ~/git/company1/nice-project/passwords
    ~/pass-store/company2 -> symlink to -> ~/git/company2/awful-project/passwords
    ~/pass-store/personal -> symlink to -> ~/mydocs/passwords

This way, you can have one password root that rofi-pass can handle, but you can still contribute to multiple projects, and encrypt the passwords correctly for each project.

This commit fixes a couple of places where find was used instead of find -L which is needed for this use-case.  Please note, that the main listing was already find -L, so this use-case was kind of supported by rofi-pass, just was a little bit buggy here and there.