### PR TITLE
Sort autotype to be always the first entry in type menu

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -405,7 +405,9 @@ typeMenu () {
   if [[ -n $default_do ]]; then
     if [[ $default_do == "menu" ]]; then
       checkIfPass
-      typefield=$(printf '%s\n' "${!stuff[@]}" | sort | _rofi -dmenu  -p "Choose Field to type > ")
+      local -a keys=(${!stuff[@]})
+      keys=(${keys[@]/$AUTOTYPE_field})
+      typefield=$({ echo ${AUTOTYPE_field} ; printf '%s\n' "${keys[@]}" | sort; } | _rofi -dmenu  -p "Choose Field to type > ")
       val=$?
       if [[ $val -eq 1 ]]; then
         exit


### PR DESCRIPTION
I would like to get this merged, so that in the type menu, the autotype is always the first entry.

I know they are alphabetically sorted, but autotype is 99% of the cases the first, and therefore I have the muscle memory of using enter+enter, instead of alt+1.  On the 1% of the entries, where there is something before autotype in the alphabet, I get annoyed and rename my field to something like z_aaa, which is just stupid.

So can we please have this exception?