### PR TITLE
Integrate OTPs into rofi-pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,24 @@ in a convenient way using [rofi](https://github.com/DaveDavenport/rofi).
   url: http://my.url.foo
   autotype: SomeField :tab UserName :tab AnotherField :tab pass
   ```
-
   You can use `:tab`, `:enter`, or `:space` here to type <kbd>Tab</kbd>,
   <kbd>Enter</kbd>, or <kbd>Space</kbd> (useful for toggling checkboxes)
   respectively.
   `:delay` will trigger a delay (2 seconds by default).
+  `:otp` will generate an OTP, either `pass-otp(1)` style, or according to the
+  `otp_method:`, if it is defined.
+* Generating OTPs.
+  The format for OTPs should either be `pass-otp(1)`-compatible
+  ```
+  [...]
+  otpauth://[...]
+  ```
+  Or it should define a method for generating OTPs:
+  ```
+  [...]
+  otp_method: /opt/obscure-otp-generator/oog --some-option some args
+  ```
+
 * All hotkeys are configurable in the config file
 * The field names for `user`, `url` and `autotype` are configurable
 * Bookmarks mode (open stored URLs in browser, default: Alt+x)
@@ -55,6 +68,7 @@ in a convenient way using [rofi](https://github.com/DaveDavenport/rofi).
 * gawk
 * bash
 * pwgen
+* pass-otp(1) (https://github.com/tadfisher/pass-otp) (optional: for OTPs)
 
 ### BSD
 

--- a/rofi-pass
+++ b/rofi-pass
@@ -318,14 +318,22 @@ mainMenu () {
       mapfile -t password_temp < <(PASSWORD_STORE_DIR="${root}" pass "${pass_file}")
       password=${password_temp[0]}
     fi
-    fields=$(printf '%s\n' "${password_temp[@]:1}" | awk '$1 ~ /:$/{$1=$1;print}')
+    fields=$(printf '%s\n' "${password_temp[@]:1}" | awk '$1 ~ /:$/ || /otpauth:\/\// {$1=$1;print}')
 
     declare -A stuff
     stuff["pass"]=${password}
     if [[ -n $fields ]]; then
       while read -r LINE; do
-        _id="${LINE%%: *}"
-        _val="${LINE#* }"
+        case "$LINE" in
+          "otpauth://"*)
+            _id="OTP"
+            _val="$(PASSWORD_STORE_DIR="${root}" pass otp "$selected_password")"
+            ;;
+          *)
+            _id="${LINE%%: *}"
+            _val="${LINE#* }"
+            ;;
+        esac
         stuff["${_id}"]=${_val}
       done < <(printf '%s\n' "${fields}")
       if test "${stuff['autotype']+autotype}"

--- a/rofi-pass
+++ b/rofi-pass
@@ -13,6 +13,7 @@ _rofi () {
 URL_field='url'
 USERNAME_field='user'
 AUTOTYPE_field='autotype'
+OTPmethod_field='otp_method'
 
 default_autotype="user :tab pass"
 delay=2
@@ -82,7 +83,7 @@ autopass () {
     ":space") xdotool key space;;
     ":delay") sleep "${delay}";;
     ":enter") xdotool key Return;;
-    ":otp") printf '%s' "$(PASSWORD_STORE_DIR="${root}" pass otp ${selected_password})" | xdotool type --clearmodifiers --file -;;
+    ":otp") printf '%s' "$(generateOTP)" | xdotool type --clearmodifiers --file -;;
     "pass") printf '%s' "${password}" | xdotool type --clearmodifiers --file -;;
     *) printf '%s' "${stuff[${word}]}" | xdotool type --clearmodifiers --file -;;
   esac
@@ -150,7 +151,7 @@ typeField () {
   xset r off
 
   case $typefield in
-    "OTP") to_type="$(PASSWORD_STORE_DIR="${root}" pass otp "$selected_password")" ;;
+    "OTP") to_type="$(generateOTP)" ;;
     *) to_type="${stuff[${typefield}]}" ;;
   esac
 
@@ -159,6 +160,21 @@ typeField () {
   xset r "$x_repeat_enabled"
   unset x_repeat_enabled
   unset to_type
+
+  clearUp
+}
+
+generateOTP () {
+  checkIfPass
+
+  # First, we check if there is a non-conventional OTP command in the pass file
+  if PASSWORD_STORE_DIR="${root}" pass "$selected_password" | grep -q "${OTPmethod_field}: "; then
+    # We execute the commands after otp_method: AS-IS
+    bash -c "$(PASSWORD_STORE_DIR="${root}" pass "$selected_password" | grep "${OTPmethod_field}: " | cut -d' ' -f2-)"
+  else
+  # If there is no method defined, fallback to pass-otp
+    PASSWORD_STORE_DIR="${root}" pass otp "$selected_password"
+  fi
 
   clearUp
 }

--- a/rofi-pass
+++ b/rofi-pass
@@ -82,6 +82,7 @@ autopass () {
     ":space") xdotool key space;;
     ":delay") sleep "${delay}";;
     ":enter") xdotool key Return;;
+    ":otp") printf '%s' "$(PASSWORD_STORE_DIR="${root}" pass otp ${selected_password})" | xdotool type --clearmodifiers --file -;;
     "pass") printf '%s' "${password}" | xdotool type --clearmodifiers --file -;;
     *) printf '%s' "${stuff[${word}]}" | xdotool type --clearmodifiers --file -;;
   esac

--- a/rofi-pass
+++ b/rofi-pass
@@ -143,14 +143,21 @@ typePass () {
 
 typeField () {
   checkIfPass
+  local to_type
 
   x_repeat_enabled=$(xset q | awk '/auto repeat:/ {print $3}')
   xset r off
 
-  printf '%s' "${stuff[${typefield}]}" | xdotool type --clearmodifiers --file -
+  case $typefield in
+    "OTP") to_type="$(PASSWORD_STORE_DIR="${root}" pass otp "$selected_password")" ;;
+    *) to_type="${stuff[${typefield}]}" ;;
+  esac
+
+  printf '%s' "$to_type" | xdotool type --clearmodifiers --file -
 
   xset r "$x_repeat_enabled"
   unset x_repeat_enabled
+  unset to_type
 
   clearUp
 }
@@ -327,7 +334,7 @@ mainMenu () {
         case "$LINE" in
           "otpauth://"*)
             _id="OTP"
-            _val="$(PASSWORD_STORE_DIR="${root}" pass otp "$selected_password")"
+            _val=""
             ;;
           *)
             _id="${LINE%%: *}"

--- a/rofi-pass
+++ b/rofi-pass
@@ -350,12 +350,9 @@ mainMenu () {
       while read -r LINE; do
         unset _id _val
         case "$LINE" in
-          "otpauth://"*)
+          "otpauth://"*|"${OTPmethod_field}"*)
             _id="OTP"
             _val=""
-            ;;
-          "${OTPmethod_field}"*)
-            # We don't show otp_method as a field that we can type
             ;;
           *)
             _id="${LINE%%: *}"

--- a/rofi-pass
+++ b/rofi-pass
@@ -348,17 +348,23 @@ mainMenu () {
     stuff["pass"]=${password}
     if [[ -n $fields ]]; then
       while read -r LINE; do
+        unset _id _val
         case "$LINE" in
           "otpauth://"*)
             _id="OTP"
             _val=""
+            ;;
+          "${OTPmethod_field}"*)
+            # We don't show otp_method as a field that we can type
             ;;
           *)
             _id="${LINE%%: *}"
             _val="${LINE#* }"
             ;;
         esac
-        stuff["${_id}"]=${_val}
+        if [[ -n "$_id" ]]; then
+          stuff["${_id}"]=${_val}
+        fi
       done < <(printf '%s\n' "${fields}")
       if test "${stuff['autotype']+autotype}"
         then


### PR DESCRIPTION
I edited rofi-pass to handle OTP (thanks to [rofi-otp(1)](https://github.com/tadfisher/pass-otp)).

A new menu item appears, once you selected an item:

    Choose a Field to type>
    ---
    autotype
    OTP
    pass
    user

The OTP is generated when we ask `rofi-pass` to type it.

It works just right on my machine, further testing would be helpful :smile: