### PR TITLE
checkIfPass: remove unnecessary `rm`

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -65,8 +65,7 @@ doClip () {
 }
 
 checkIfPass () {
-    rm -f "$HOME/.cache/rofi-pass/last_used"
-    printf '%s\n' "${root}: $selected_password" > "$HOME/.cache/rofi-pass/last_used"
+    printf '%s\n' "${root}: $selected_password" >| "$HOME/.cache/rofi-pass/last_used"
 }
 
 


### PR DESCRIPTION
Uses `>|` to work also with the `noclobber` option being enabled.