### PR TITLE
Fix password -> pass typo in typeMenu

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -420,7 +420,7 @@ typeMenu () {
       fi
       case "$typefield" in
         '') exit;;
-        'password') sleep $wait; typePass;;
+        'pass') sleep $wait; typePass;;
         "${AUTOTYPE_field}") sleep $wait; autopass;;
         *) sleep $wait; typeField
       esac


### PR DESCRIPTION
This was not causing any big problems, because the only difference
between typeField (the default fallback of the switch statement) and
typePass functions is the handling of notifications.

This PR previously was secretly part of #94, but now I'm separating it, because #94 looks like a bigger project now.