### PR TITLE
Add ROFI_PASS_DEFAULT_USER environment variable

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -23,7 +23,7 @@ auto_enter='false'
 notify='false'
 help_color=""
 clip=primary
-default_user="$(whoami)"
+default_user="${ROFI_PASS_DEFAULT_USER-$(whoami)}"
 default_user2=john_doe
 password_length=12
 


### PR DESCRIPTION
This leaves the current behavior intact and is very portable across shells sh/bash/zsh, though this should not matter since the shell is explicitly specified.