### PR TITLE
Ditch xdotool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ endif
 install:
 	install -Dm755 rofi-pass $(DESTDIR)$(PREFIX)/bin/rofi-pass
 	install -Dm755 addpass $(DESTDIR)$(PREFIX)/bin/addpass
+	install -Dm755 emulatekb $(DESTDIR)$(PREFIX)/bin/emulatekb
 	install -Dm644 config.example $(DESTDIR)$(PREFIX)/share/doc/rofi-pass/config.example
 	install -Dm644 README.md $(DESTDIR)$(PREFIX)/share/doc/rofi-pass/README.md
 	install -Dm644 config.example $(DESTDIR)/etc/rofi-pass.conf

--- a/emulatekb
+++ b/emulatekb
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+from pynput.keyboard import Key, Controller
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} TEXT")
+    sys.exit(1)
+
+kb = Controller()
+kb.type(sys.argv[1])

--- a/rofi-pass
+++ b/rofi-pass
@@ -78,17 +78,17 @@ autopass () {
   printf '%s\n' "${root}: $selected_password" > "$HOME/.cache/rofi-pass/last_used"
   for word in ${stuff["$AUTOTYPE_field"]}; do
   case "$word" in
-    ":tab") xdotool key Tab;;
-    ":space") xdotool key space;;
+    ":tab") emulatekb $'\t';;
+    ":space") emulatekb ' ';;
     ":delay") sleep "${delay}";;
-    ":enter") xdotool key Return;;
-    ":otp") printf '%s' "$(generateOTP)" | xdotool type --clearmodifiers --file -;;
-    "pass") printf '%s' "${password}" | xdotool type --clearmodifiers --file -;;
-    *) printf '%s' "${stuff[${word}]}" | xdotool type --clearmodifiers --file -;;
+    ":enter") emulatekb $'\n';;
+    ":otp") emulatekb "$(generateOTP)" ;;
+    "pass") emulatekb "${password}" ;;
+    *) emulatekb "${stuff[${word}]}" ;;
   esac
   done
   if [[ ${auto_enter} == "true" ]]; then
-    xdotool key Return
+    emulatekb $'\n'
   fi
   xset r "$x_repeat_enabled"
   unset x_repeat_enabled
@@ -107,7 +107,7 @@ typeUser () {
   x_repeat_enabled=$(xset q | awk '/auto repeat:/ {print $3}')
   xset r off
 
-  printf '%s' "${stuff[${USERNAME_field}]}" | xdotool type --clearmodifiers --file -
+  emulatekb "${stuff[${USERNAME_field}]}"
 
   xset r "$x_repeat_enabled"
   unset x_repeat_enabled
@@ -121,7 +121,7 @@ typePass () {
   x_repeat_enabled=$(xset q | awk '/auto repeat:/ {print $3}')
   xset r off
 
-  printf '%s' "${password}" | xdotool type --clearmodifiers --file -
+  emulatekb "${password}"
   if [[ $notify == "true" ]]; then
     if [[ "${stuff[notify]}" == "false" ]]; then
       :
@@ -154,7 +154,7 @@ typeField () {
     *) to_type="${stuff[${typefield}]}" ;;
   esac
 
-  printf '%s' "$to_type" | xdotool type --clearmodifiers --file -
+  emulatekb "$to_type"
 
   xset r "$x_repeat_enabled"
   unset x_repeat_enabled


### PR DESCRIPTION
I've just got fed up with xdotool. I reduced my password character set to bare
minimum but it appears that xdotool translates `=` on input to `-`. In this pull
request I attached simple script `emulatekb` which uses pynput Python library
which probably uses evdev directly.