### PR TITLE
Allow to use the password filename as user

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -417,7 +417,11 @@ mainMenu () {
 	fi
 	if [[ -z "${stuff["${USERNAME_field}"]}" ]]; then
 		if [[ -n $default_user ]]; then
-			stuff["${USERNAME_field}"]="${default_user}"
+		    if [[ "$default_user" == "%filename" ]]; then
+		      stuff["${USERNAME_field}"]="$(basename $selected_password)"
+		    else
+    			stuff["${USERNAME_field}"]="${default_user}"
+    	  fi
 		fi
 	fi
 	pass_content="$(for key in "${!stuff[@]}"; do printf '%s\n' "${key}: ${stuff[$key]}"; done)"


### PR DESCRIPTION
Hi,

I generally store unsensitive username directly in the name of my password file, for example for github : `web/github.com/takuyozora`. That reduce redundant entry.

So I've wrote a simple patch to rofi-pass to allow getting username from filename if the config variable `default_user` is set to `%filename`.

I thinks that there isn't any drawbacks and it can be useful for some other people.