### PR TITLE
allow to use directory name as url

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -135,7 +135,11 @@ generateQrCode() {
 
 openURL () {
 	checkIfPass
-	$BROWSER "$(PASSWORD_STORE_DIR="${root}" pass "$selected_password" | grep "${URL_field}: " | gawk '{sub(/:/,"")}{print $2}1' | head -1)"; exit;
+	local url="$(PASSWORD_STORE_DIR="${root}" pass "$selected_password" | grep "${URL_field}: " | gawk '{sub(/:/,"")}{print $2}1' | head -1)"
+	if [ "$url" == "" ]; then
+	  url="$(basename $(dirname $selected_password))"
+	fi
+	$BROWSER "$url"; exit;
 	clearUp
 }
 


### PR DESCRIPTION
Hi,

Same idea that https://github.com/carnager/rofi-pass/pull/138, I've wrote a small patch to allow the password directory name to by used as URL, so for example, with :`web/github.com/takuyozora` the URL will be `github.com`.