### PR TITLE
Allow to use the password filename as user

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Rofi-pass allows you to easily share common used passwords across multiple entri
 For example, if you have an academic account which includes several services (such as a library, Salary, Student portal etc),  all with different URL's, login forms etc. you can share one password across all of them. This is very handy when the passwords change annually.
 To use this function you need to add the following line instead of the password, referencing a pass file which holds the password.
 
+## User filename as user
+
+If your password file has no user field you can ask rofi-pass to use the filename instead.
+For example with this password file path : `web/fsf.org/rms` rofi-pass will user `rms` as your username.
+To get this, you need to set `default_user` to `:filename` in your configuration.
+
 ```
 #FILE=PATH/to/filename
 ```

--- a/rofi-pass
+++ b/rofi-pass
@@ -417,7 +417,7 @@ mainMenu () {
 	fi
 	if [[ -z "${stuff["${USERNAME_field}"]}" ]]; then
 		if [[ -n $default_user ]]; then
-		    if [[ "$default_user" == "%filename" ]]; then
+		    if [[ "$default_user" == ":filename" ]]; then
 		      stuff["${USERNAME_field}"]="$(basename $selected_password)"
 		    else
     			stuff["${USERNAME_field}"]="${default_user}"

--- a/rofi-pass
+++ b/rofi-pass
@@ -417,7 +417,11 @@ mainMenu () {
 	fi
 	if [[ -z "${stuff["${USERNAME_field}"]}" ]]; then
 		if [[ -n $default_user ]]; then
-			stuff["${USERNAME_field}"]="${default_user}"
+		    if [[ "$default_user" == "%filename" ]]; then
+		      stuff["${USERNAME_field}"]="$(basename $selected_password)"
+		    else
+    			stuff["${USERNAME_field}"]="${default_user}"
+    	  fi
 		fi
 	fi
 	pass_content="$(for key in "${!stuff[@]}"; do printf '%s\n' "${key}: ${stuff[$key]}"; done)"


### PR DESCRIPTION
Same as https://github.com/carnager/rofi-pass/pull/138 but I've add documentation and change `%filename` to `:filename` 