### PR TITLE
Fixed ctrl key getting stuck

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -89,7 +89,7 @@ autopass () {
 	printf '%s\n' "${root}: $selected_password" > "$HOME/.cache/rofi-pass/last_used"
 	for word in ${stuff["$AUTOTYPE_field"]}; do
 		case "$word" in
-			":tab") xdotool key Tab;;
+			":tab") xdotool keyup Control_L Control_R; xdotool key Tab --clearmodifiers;;
 			":space") xdotool key space;;
 			":delay") sleep "${delay}";;
 			":enter") xdotool key Return;;


### PR DESCRIPTION
When using Ctrl-m to confirm the selection in rofi (same as "Return"), xdotool store the state of the control modifiers and restore it later, but it fails to register the keyup event, resulting in a "stuck control" behaviour. 
Using just:
`xdotool key Tab --clearmodifiers`
Fixes the issues, but if the Control key is still being pressed (happens when usernames are small), it will still result in a Control+Tab event. 
Sending a keyup event to both control modifiers before pressing Tab fixes both issues, it is done using
`xdotool keyup Control_L Control_R`

