### PR TITLE
Honor default_autotype setting

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -404,12 +404,6 @@ mainMenu () {
 					stuff["${_id}"]=${_val}
 				fi
 			done < <(printf '%s\n' "${fields}")
-
-			if test "${stuff['autotype']+autotype}"; then
-				:
-			else
-				stuff["autotype"]="${USERNAME_field} :tab pass"
-			fi
 		fi
 	fi
 


### PR DESCRIPTION
It looks like the default_autotype setting is not currently honored.

In this PR I removed some lines that look like leftovers from a previous version. The removal seems to fix the issue.