### PR TITLE
Support otp secret on the first line

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -411,6 +411,11 @@ mainMenu () {
 				stuff["autotype"]="${USERNAME_field} :tab pass"
 			fi
 		fi
+
+		if [[ "$password" == "otpauth://"* || "$password" == "${OTPmethod_field}"* ]]; then
+			stuff["OTP"]=""
+		fi
+
 	fi
 
 	if [[ -z "${stuff["${AUTOTYPE_field}"]}" ]]; then


### PR DESCRIPTION
`pass-otp` allows a workflow in which each otp secret is stored in its own file, separate from the password file for that account. This change allows rofi-pass to generate OTP codes for such files.