### PR TITLE
Follow symlinks while listing keys

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -63,7 +63,7 @@ has_qrencode() {
 # get all password files and create an array
 list_passwords() {
 	cd "${root}" || exit
-	pw_list=(**/*.gpg)
+   pw_list=($(find -L * -name "*.gpg"))
 	printf '%s\n' "${pw_list[@]%.gpg}" | sort -n
 
 }


### PR DESCRIPTION
Currently, pass handles symlinks but rofi-pass does not show them. This PR replaces the listing of passwords using `find -L` to allow this.