### PR TITLE
Add default _pwgen() implementation

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -9,6 +9,10 @@ _rofi () {
 	rofi -no-auto-select -i "$@"
 }
 
+_pwgen () {
+	pwgen -y "$@"
+}
+
 _image_viewer () {
 	feh -
 }


### PR DESCRIPTION
This seems to have been an oversight when `pwgen()` was made configurable. This fixes generation of new passwords for the default case.