### PR TITLE
Add clip=wayland option for use with wl-clipboard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ in a convenient way using [rofi](https://github.com/DaveDavenport/rofi).
 * bash 4.x
 * pwgen
 * [pass-otp](https://github.com/tadfisher/pass-otp) (optional: for OTPs)
+* [wl-clipboard](https://github.com/bugaevc/wl-clipboard) (optional: for use with Wayland)
 
 ### BSD
 

--- a/config.example
+++ b/config.example
@@ -64,7 +64,11 @@ default_autotype='user :tab pass'
 help_color="#4872FF"
 
 # Clipboard settings
-# Possible options: primary, clipboard, both
+# Possible options:
+#  - primary (X11),
+#  - clipboard (X11),
+#  - both (both of the above)
+#  - wayland (needs wl-copy from wl-clipboard)
 clip=primary
 
 # Seconds before clearing pass from clipboard 

--- a/rofi-pass
+++ b/rofi-pass
@@ -77,6 +77,7 @@ doClip () {
 		"primary") xclip ;;
 		"clipboard") xclip -selection clipboard;;
 		"both") xclip; xclip -o | xclip -selection clipboard;;
+		"wayland") wl-copy -o ;;
 	esac
 }
 


### PR DESCRIPTION
wl-clipboard can be found at https://github.com/bugaevc/wl-clipboard,
and is available in the Arch Linux community repository.
It provides the `wl-copy` command, which is a wayland alternative for xclip.

---

I've been using a `doClip` override in my config ever since I'm running sway, with that line. I heard interest in the #sway channel on freenode, hence this PR.