### PR TITLE
Use find instead of globstar so we follow symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ in a convenient way using [rofi](https://github.com/DaveDavenport/rofi).
 * xdotool
 * gawk
 * bash 4.x
+* find
 * pwgen
 * [pass-otp](https://github.com/tadfisher/pass-otp) (optional: for OTPs)
 

--- a/rofi-pass
+++ b/rofi-pass
@@ -69,10 +69,7 @@ has_qrencode() {
 
 # get all password files and create an array
 list_passwords() {
-	cd "${root}" || exit
-	pw_list=(**/*.gpg)
-	printf '%s\n' "${pw_list[@]%.gpg}" | sort -n
-
+	find -L "${root}" -name \*.gpg -printf '%P\n' | sed 's/\.gpg$//g' | sort -n
 }
 
 doClip () {
@@ -672,8 +669,7 @@ manageEntry () {
 }
 
 listgpg () {
-	pw_list=(**/*.gpg)
-	printf '%s\n' "${pw_list[@]}" | sort -n
+	find -L . -name \*.gpg -printf '%P\n' | sort -n
 }
 
 insertPass () {
@@ -792,9 +788,6 @@ get_config_file () {
 }
 
 main () {
-	# enable extended globbing
-	shopt -s nullglob globstar
-
 	# load config file
 	config_file="$(get_config_file)"
 	[[ ! -z "$config_file" ]] && source "$config_file"


### PR DESCRIPTION
The behaviour of Bash's globstar changed. It used to follow symlinks but no
longer does. Symlinks are well-supported by pass (accidentally or
intentionally)

Use 'find' instead to restore symlink compatibility

Fixes #191