### PR TITLE
Fix handling of filenames with spaces (regression from #191)

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -67,12 +67,10 @@ has_qrencode() {
 	command -v qrencode >/dev/null 2>&1
 }
 
-# get all password files and create an array
+# get all password files and ouput as newline-delimited text
 list_passwords() {
 	cd "${root}" || exit
-   pw_list=($(find -L * -name "*.gpg"))
-	printf '%s\n' "${pw_list[@]%.gpg}" | sort -n
-
+	find -L * -name "*.gpg" | sed -e 's/.gpg$//' | sort -n
 }
 
 doClip () {

--- a/rofi-pass
+++ b/rofi-pass
@@ -100,7 +100,7 @@ autopass () {
 			":enter") xdotool key Return;;
 			":otp") printf '%s' "$(generateOTP)" | xdotool type --delay ${xdotool_delay} --clearmodifiers --file -;;
 			"pass") printf '%s' "${password}" | xdotool type --delay ${xdotool_delay} --clearmodifiers --file -;;
- 			"path") printf '%s' "${selected_password}" | rev | cut -d'/' -f1 | rev | xdotool type --clearmodifiers --file -;;
+			"path") printf '%s' "${selected_password}" | rev | cut -d'/' -f1 | rev | xdotool type --clearmodifiers --file -;;
 			*) printf '%s' "${stuff[${word}]}" | xdotool type --delay ${xdotool_delay} --clearmodifiers --file -;;
 		esac
 	done
@@ -426,10 +426,10 @@ mainMenu () {
 	if [[ -z "${stuff["${USERNAME_field}"]}" ]]; then
 		if [[ -n $default_user ]]; then
 			if [[ "$default_user" == ":filename" ]]; then
-		    	stuff["${USERNAME_field}"]="$(basename $selected_password)"
-		    else
-		    	stuff["${USERNAME_field}"]="${default_user}"
-    		fi
+				stuff["${USERNAME_field}"]="$(basename $selected_password)"
+			else
+				stuff["${USERNAME_field}"]="${default_user}"
+			fi
 		fi
 	fi
 	pass_content="$(for key in "${!stuff[@]}"; do printf '%s\n' "${key}: ${stuff[$key]}"; done)"
@@ -613,7 +613,7 @@ showEntry () {
 			fi
 			if [[ $notify == "true" ]]; then
 				(sleep $clip_clear; printf '%s' "" | xclip; printf '%s' "" | xclip -selection clipboard | notify-send "rofi-pass" "Clipboard cleared") &
-			elif [[ $notify == "false" ]]; 	then
+			elif [[ $notify == "false" ]];	then
 				(sleep $clip_clear; printf '%s' "" | xclip; printf '%s' "" | xclip -selection clipboard) &
 			fi
 			exit


### PR DESCRIPTION
I just pulled in the latest changes and found that my password list was very broken - I have many password files with spaces in them. I looked into it and found that the changes in #191 make it so such files are broken into multiple entries, one per word, which is very much not desirable.

Trying to split lines into a bash array proved troublesome, so since the function wasn't actually using the bash array and just used it to generate a newline-delimited string, I replaced the bash array and string processing with sed and called it a day. Hopefully that's within scope!

#191 also introduced some line-leading spaces, I tidied those up and also grabbed a couple other spaces that had snuck in as well while I was at it.