### PR TITLE
Fix delay arguments for ydotool

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -113,6 +113,7 @@ autopass () {
 			":space") _xdotool key " ";;
 			":delay") sleep "${delay}";;
 			":enter") _xdotool key enter;;
+			":esc"|":escape") _xdotool key esc;;
 			":otp") printf '%s' "$(generateOTP)" | _xdotool type --key-delay ${xdotool_delay} --file /dev/stdin;;
 			"pass") printf '%s' "${password}" | _xdotool type --key-delay ${xdotool_delay} --file /dev/stdin;;
  			"path") printf '%s' "${selected_password}" | rev | cut -d'/' -f1 | rev | _xdotool type --file /dev/stdin;;

--- a/rofi-pass
+++ b/rofi-pass
@@ -107,7 +107,7 @@ autopass () {
 
 	rm -f "$HOME/.cache/rofi-pass/last_used"
 	printf '%s\n' "${root}: $selected_password" > "$HOME/.cache/rofi-pass/last_used"
-	for word in ${stuff["$AUTOTYPE_field"]}; do
+	for word in ${stuff["$1"]}; do
 		case "$word" in
 			":tab") _xdotool key tab;;
 			":space") _xdotool key " ";;
@@ -453,7 +453,7 @@ mainMenu () {
 	# The exit code for -kb-custom-X is X+9.
 	case "${rofi_exit}" in
 		0) typeMenu;;
-		10) sleep $wait; autopass;;
+		10) sleep $wait; autopass $AUTOTYPE_field;;
 		11) sleep $wait; typeUser;;
 		12) sleep $wait; typePass;;
 		13) openURL;;
@@ -525,12 +525,12 @@ typeMenu () {
 			case "$typefield" in
 				'') exit;;
 				'pass') sleep $wait; typePass;;
-				"${AUTOTYPE_field}") sleep $wait; autopass;;
+				"auto"*) sleep $wait; autopass $typefield;;
 				*) sleep $wait; typeField
 			esac
 			clearUp
-		elif [[ $default_do == "${AUTOTYPE_field}" ]]; then
-			sleep $wait; autopass
+		elif [[ $default_do == "auto"* ]]; then
+			sleep $wait; autopass $default_do
 		else
 			${default_do}
 		fi

--- a/rofi-pass
+++ b/rofi-pass
@@ -108,10 +108,10 @@ autopass () {
 			":space") _xdotool key " ";;
 			":delay") sleep "${delay}";;
 			":enter") _xdotool key enter;;
-			":otp") printf '%s' "$(generateOTP)" | _xdotool type ${xdotool_delay} --file /dev/stdin;;
-			"pass") printf '%s' "${password}" | _xdotool type ${xdotool_delay} --file /dev/stdin;;
+			":otp") printf '%s' "$(generateOTP)" | _xdotool type --key-delay ${xdotool_delay} --file /dev/stdin;;
+			"pass") printf '%s' "${password}" | _xdotool type --key-delay ${xdotool_delay} --file /dev/stdin;;
  			"path") printf '%s' "${selected_password}" | rev | cut -d'/' -f1 | rev | _xdotool type --file /dev/stdin;;
-			*) printf '%s' "${stuff[${word}]}" | _xdotool type --delay ${xdotool_delay} --file /dev/stdin;;
+			*) printf '%s' "${stuff[${word}]}" | _xdotool type --key-delay ${xdotool_delay} --file /dev/stdin;;
 		esac
 	done
 
@@ -163,7 +163,7 @@ typeUser () {
 	x_repeat_enabled=$(xset q | awk '/auto repeat:/ {print $3}')
 	xset r off
 
-	printf '%s' "${stuff[${USERNAME_field}]}" | _xdotool type --delay ${xdotool_delay} --file /dev/stdin
+	printf '%s' "${stuff[${USERNAME_field}]}" | _xdotool type --key-delay ${xdotool_delay} --file /dev/stdin
 
 	xset r "$x_repeat_enabled"
 	unset x_repeat_enabled
@@ -177,7 +177,7 @@ typePass () {
 	x_repeat_enabled=$(xset q | awk '/auto repeat:/ {print $3}')
 	xset r off
 
-	printf '%s' "${password}" | _xdotool type ${xdotool_delay} --file /dev/stdin
+	printf '%s' "${password}" | _xdotool type --key-delay ${xdotool_delay} --file /dev/stdin
 
 	if [[ $notify == "true" ]]; then
 		if [[ "${stuff[notify]}" == "false" ]]; then
@@ -210,7 +210,7 @@ typeField () {
 		*) to_type="${stuff[${typefield}]}" ;;
 	esac
 
-	printf '%s' "$to_type" | _xdotool type ${xdotool_delay} --file /dev/stdin
+	printf '%s' "$to_type" | _xdotool type --key-delay ${xdotool_delay} --file /dev/stdin
 
 	xset r "$x_repeat_enabled"
 	unset x_repeat_enabled

--- a/rofi-pass
+++ b/rofi-pass
@@ -13,17 +13,21 @@ _image_viewer () {
 	feh -
 }
 
-_xdotool () {
-	if [[ $backend == "xdotool" ]]; then
-		xdotool "$@"
-	elif [[ $backend == "ydotool" ]]; then
+start_ydotool () {
+	if [[ $backend == "ydotool" ]]; then
 		if pgrep -x "ydotoold" >/dev/null; then
 			printf "%s\n" "ydotool daemon already running"
 		else
 			printf "%s\n" "starting daemon"
 			ydotoold&
-			sleep 0.1
 		fi
+	fi
+}
+
+_xdotool () {
+	if [[ $backend == "xdotool" ]]; then
+		xdotool "$@"
+	elif [[ $backend == "ydotool" ]]; then
 		ydotool "$@"
 	fi
 }
@@ -846,6 +850,7 @@ main () {
 	roots_length=${#roots[@]}
 	export root=${roots[$roots_index]}
 	export PASSWORD_STORE_DIR="${root}"
+	start_ydotool
 	case $1 in
 		--insert)
 			insertPass

--- a/rofi-pass
+++ b/rofi-pass
@@ -22,6 +22,7 @@ _xdotool () {
 		else
 			printf "%s\n" "starting daemon"
 			ydotoold&
+			sleep 0.1
 		fi
 		ydotool "$@"
 	fi


### PR DESCRIPTION
Adapt to a change in ydotool, where the "--delay" argument got renamed to "--key-delay".
Additionally many missing delay arguments are added.

This issue was mentioned in https://github.com/carnager/rofi-pass/issues/165#issuecomment-762754734.
It also fixes the autotype functionality for me, which did only type the password and none of the other fields.