### PR TITLE
Add support for other backends (wtype)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,22 @@ in a convenient way using [rofi](https://github.com/DaveDavenport/rofi).
 * The field names for `user`, `url` and `autotype` are configurable
 * Bookmarks mode (open stored URLs in browser, default: Alt+x)
 * Share common used passwords between several entries (with different URLs, usernames etc)
+* Change backend with environment variable `ROFI_PASS_BACKEND`, valid
+  backends are `xdotool` or `wtype`. For example use `rofi-pass` with
+  [wtype](https://github.com/atx/wtype):
 
+  ```
+  ROFI_PASS_BACKEND=wtype rofi-pass
+  ```
+
+  Alternative change the backend in the config file using
+  `backend=wtype`.
 ## Requirements
 
 * [pass](http://www.passwordstore.org/)
 * sed
 * [rofi](https://github.com/DaveDavenport/rofi)
-* xdotool
+* xdotool or wtype
 * gawk
 * bash 4.x
 * find

--- a/config.example
+++ b/config.example
@@ -122,3 +122,8 @@ type_menu="Alt+t"
 help="Alt+h"
 switch="Alt+x"
 insert_pass="Alt+n"
+
+# Change the backend for rofi-pass, valid backends are:
+# xdotool
+# wtype
+#backend=xdotool

--- a/rofi-pass
+++ b/rofi-pass
@@ -856,10 +856,13 @@ main () {
 		mkdir -p "$cache_dir/rofi-pass"
 	fi
 
-	# fix keyboard layout if enabled in config
-	if [[ $fix_layout == "true" ]]; then
-		layout_cmd
-	fi
+        # Only valid for the xdotool backend
+        if [[ $backend == "xdotool" ]]; then
+		# fix keyboard layout if enabled in config
+		if [[ $fix_layout == "true" ]]; then
+			layout_cmd
+		fi
+        fi
 
 	# set help color
 	if [[ $help_color == "" ]]; then

--- a/rofi-pass
+++ b/rofi-pass
@@ -76,9 +76,31 @@ insert_pass="Alt+n"
 qrcode="Alt+q"
 previous_root="Shift+Left"
 next_root="Shift+Right"
+backend=${ROFI_PASS_BACKEND:-xdotool}
+
+case "$backend" in
+    "xdotool");;
+    *)
+        >&2 echo "Invalid backend '$backend', falling back to xdotool"
+        backend=xdotool
+        ;;
+esac
 
 # Safe permissions
 umask 077
+
+# Backends for typing what's in stdin
+_do_type_xdotool() {
+	xdotool type --delay ${xdotool_delay} --clearmodifiers --file -
+}
+
+# Backends for pressing the key specified by the first argument ($1)
+_do_press_key_xdotool() {
+	xdotool key "$1"
+}
+
+do_type=_do_type_${backend}
+do_press_key=_do_press_key_${backend}
 
 has_qrencode() {
 	command -v qrencode >/dev/null 2>&1
@@ -118,19 +140,19 @@ autopass () {
 	printf '%s\n' "${root}: $selected_password" > "$cache_dir/rofi-pass/last_used"
 	for word in ${stuff["$AUTOTYPE_field"]}; do
 		case "$word" in
-			":tab") xdotool key Tab;;
-			":space") xdotool key space;;
+			":tab") ${do_press_key} Tab;;
+			":space") ${do_press_key} space;;
 			":delay") sleep "${delay}";;
-			":enter") xdotool key Return;;
-			":otp") printf '%s' "$(generateOTP)" | xdotool type --delay ${xdotool_delay} --clearmodifiers --file -;;
-			"pass") printf '%s' "${password}" | xdotool type --delay ${xdotool_delay} --clearmodifiers --file -;;
-			"path") printf '%s' "${selected_password}" | rev | cut -d'/' -f1 | rev | xdotool type --clearmodifiers --file -;;
-			*) printf '%s' "${stuff[${word}]}" | xdotool type --delay ${xdotool_delay} --clearmodifiers --file -;;
+			":enter") ${do_press_key} Return;;
+			":otp") printf '%s' "$(generateOTP)" | ${do_type};;
+			"pass") printf '%s' "${password}" | ${do_type};;
+			"path") printf '%s' "${selected_password}" | rev | cut -d'/' -f1 | rev | ${do_type};;
+			*) printf '%s' "${stuff[${word}]}" | ${do_type};;
 		esac
 	done
 
 	if [[ ${auto_enter} == "true" ]]; then
-		xdotool key Return
+		${do_press_key} Return
 	fi
 
 	xset r "$x_repeat_enabled"
@@ -177,7 +199,7 @@ typeUser () {
 	x_repeat_enabled=$(xset q | awk '/auto repeat:/ {print $3}')
 	xset r off
 
-	printf '%s' "${stuff[${USERNAME_field}]}" | xdotool type --delay ${xdotool_delay} --clearmodifiers --file -
+	printf '%s' "${stuff[${USERNAME_field}]}" | ${do_type}
 
 	xset r "$x_repeat_enabled"
 	unset x_repeat_enabled
@@ -191,7 +213,7 @@ typePass () {
 	x_repeat_enabled=$(xset q | awk '/auto repeat:/ {print $3}')
 	xset r off
 
-	printf '%s' "${password}" | xdotool type --delay ${xdotool_delay} --clearmodifiers --file -
+	printf '%s' "${password}" | ${do_type}
 
 	if [[ $notify == "true" ]]; then
 		if [[ "${stuff[notify]}" == "false" ]]; then
@@ -224,7 +246,7 @@ typeField () {
 		*) to_type="${stuff[${typefield}]}" ;;
 	esac
 
-	printf '%s' "$to_type" | xdotool type --delay ${xdotool_delay} --clearmodifiers --file -
+	printf '%s' "$to_type" | ${do_type}
 
 	xset r "$x_repeat_enabled"
 	unset x_repeat_enabled

--- a/rofi-pass
+++ b/rofi-pass
@@ -80,6 +80,7 @@ backend=${ROFI_PASS_BACKEND:-xdotool}
 
 case "$backend" in
     "xdotool");;
+    "wtype");;
     *)
         >&2 echo "Invalid backend '$backend', falling back to xdotool"
         backend=xdotool
@@ -94,9 +95,17 @@ _do_type_xdotool() {
 	xdotool type --delay ${xdotool_delay} --clearmodifiers --file -
 }
 
+_do_type_wtype() {
+	wtype -
+}
+
 # Backends for pressing the key specified by the first argument ($1)
 _do_press_key_xdotool() {
 	xdotool key "$1"
+}
+
+_do_press_key_wtype() {
+	wtype -P "$1" -p "$1"
 }
 
 do_type=_do_type_${backend}


### PR DESCRIPTION
Add support to add other backends than `xdotool`. By refactoring the `xdotool` calls into two function calls.

- do_type: variable containing a function that reads from `stdin` and type it out.
- do_press_key: variable containing a function that presses the key specified by the first input (`$1`) to the function.

The `xdotool` calls now live in `_do_type_xdotool` and `_do_press_key_xdotool` which are the default assigned to the `do_type` and `do_press_key` respectively.

I also added a backend for `wtype` as I'm using a wayland wm and cannot use X or `ydotool`.
