### PR TITLE
Fix default_autotype

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -436,12 +436,6 @@ mainMenu () {
 					stuff["${_id}"]=${_val}
 				fi
 			done < <(printf '%s\n' "${fields}")
-
-			if test "${stuff['autotype']+autotype}"; then
-				:
-			else
-				stuff["autotype"]="${USERNAME_field} :tab pass"
-			fi
 		fi
 	fi
 


### PR DESCRIPTION
This if statement is unnecessary and breaks default_autotype functionality.
```stuff["autotype"]``` will be set to ```user :tab pass``` no matter what entered as default_autotype.

After this change default_autotype works and autotype override works also.