### PR TITLE
Use the quiet flag for pass otp

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -242,7 +242,7 @@ generateOTP () {
 		bash -c "$(PASSWORD_STORE_DIR="${root}" pass "$selected_password" | grep "${OTPmethod_field}: " | cut -d' ' -f2-)"
 	else
 		# If there is no method defined, fallback to pass-otp
-		PASSWORD_STORE_DIR="${root}" pass otp "$selected_password"
+		PASSWORD_STORE_DIR="${root}" pass otp -q "$selected_password"
 	fi
 
 	clearUp


### PR DESCRIPTION
For users of git in password store the standard output of `pass otp` includes
the git update message which is not a wanted behaviour.